### PR TITLE
Add a silly dot before 'ts-prunerc' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ CLI configuration options:
 ```bash 
 ts-prune -p my-tsconfig.json -i my-component-ignore-patterns?
 ```
-Configuration file example `ts-prunerc`: 
+Configuration file example `.ts-prunerc`: 
 ```json
 {
   "ignore": "my-component-ignore-patterns?"


### PR DESCRIPTION
The amount of time it took me to realize what my mistake was was intensely silly.